### PR TITLE
Error message:"not-authorized" after 19HS 12/03/15

### DIFF
--- a/WhatsAppApi/Settings/WhatsConstants.cs
+++ b/WhatsAppApi/Settings/WhatsConstants.cs
@@ -37,7 +37,7 @@ namespace WhatsAppApi.Settings
         /// <summary>
         /// The whatsapp version the client complies to
         /// </summary>
-		public const string WhatsAppVer = "2.12.96";
+		public const string WhatsAppVer = "2.13.21";
 
         /// <summary>
         /// The port that needs to be connected to
@@ -52,7 +52,7 @@ namespace WhatsAppApi.Settings
         /// <summary>
         /// The useragent used for http requests
         /// </summary>
-		public const string UserAgent = "WhatsApp/2.12.96 S40Version/14.26 Device/Nokia302";
+		public const string UserAgent = "WhatsApp/2.13.21 S40Version/14.26 Device/Nokia302";
 
         #endregion
 


### PR DESCRIPTION
I solved this error updating the version "2.12.96" to "2.13.21". This is the same on the Chat-Api